### PR TITLE
AP-5317: creates /workload route

### DIFF
--- a/src/routes/workload.ts
+++ b/src/routes/workload.ts
@@ -42,6 +42,16 @@ export const workload = async ( { req, res } : RouteProps ) => {
                         let orgUser = Object.values( OrganizationLinks ).find( orgLink => orgLink.github === rev.name );
     
                         if ( orgUser ) {
+
+                            if ( !people[ orgUser.name ] ) {
+                                people[ orgUser.name ] = {
+                                    email: orgUser.email,
+                                    github: orgUser.github,
+                                    tickets: { count: 0, data: [] },
+                                    reviewing: { count: 0, data: [] }
+                                }
+                            }
+
                             people[ orgUser.name ].reviewing.count += 1;
     
                             people[ orgUser.name ].reviewing.data.push({


### PR DESCRIPTION
## What Pull Request Does:
It creates a route for you to see the workload of a person on the dev team

Side Note:
> When testing the pull request, the data you might be expecting to get may be incomplete. I say this because Github is having a issue of not giving me / my api key access to all active repos pull request. So if you see a ticket that says it has a pull request but do not see the pull request that is the reason. 

> Secondly because of the pull request data is not working properly, the reviewer data return may not be accurate for a dev. But if it does return accurate data in pull request please expect for the reviewer count to be accurate as well.

## What To Test:
- No errors that shut server down
- Able to get the ticket, pull request and reviewing data for all devs on the team accurately.

## [Link To Jira Ticket](https://docnetwork.atlassian.net/browse/AP-5317)